### PR TITLE
Orderbook rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,20 +356,19 @@ import cbpro, time, Queue
 class myWebsocketClient(cbpro.WebsocketClient):
     def on_open(self):
         self.products = ['BTC-USD', 'ETH-USD']
-        self.websocket_queue = Queue.Queue()
+        self.order_book_btc = OrderBookConsole(product_id='BTC-USD')
+        self.order_book_eth = OrderBookConsole(product_id='ETH-USD')
     def on_message(self, msg):
-        self.websocket_queue.put(msg)
+        self.order_book_btc.process_message(msg)
+        self.order_book_eth.process_message(msg)
 
-order_book_btc = cbpro.OrderBook(product_id='BTC-USD')
-order_book_eth = cbpro.OrderBook(product_id='ETH-USD')
 wsClient = myWebsocketClient()
 wsClient.start()
 time.sleep(10)
 while True:
-    msg = wsClient.websocket_queue.get(timeout=15)
-    order_book.process_message(msg)
-    print(order_book_btc.get_ask())
-    print(order_book_eth.get_bid())
+    print(wsClient.order_book_btc.get_ask())
+    print(wsClient.order_book_eth.get_bid())
+    time.sleep(1)
 ```
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -346,16 +346,30 @@ python -m pytest
 ```
 
 ### Real-time OrderBook
-The ```OrderBook``` subscribes to a websocket and keeps a real-time record of
-the orderbook for the product_id input.  Please provide your feedback for future
+The ```OrderBook``` is a convenient data structure to keep a real-time record of
+the orderbook for the product_id input. It processes incoming messages from an
+already existing WebsocketClient. Please provide your feedback for future
 improvements.
 
 ```python
-import cbpro, time
-order_book = cbpro.OrderBook(product_id='BTC-USD')
-order_book.start()
+import cbpro, time, Queue
+class myWebsocketClient(cbpro.WebsocketClient):
+    def on_open(self):
+        self.products = ['BTC-USD', 'ETH-USD']
+        self.websocket_queue = Queue.Queue()
+    def on_message(self, msg):
+        self.websocket_queue.put(msg)
+
+order_book_btc = cbpro.OrderBook(product_id='BTC-USD')
+order_book_eth = cbpro.OrderBook(product_id='ETH-USD')
+wsClient = myWebsocketClient()
+wsClient.start()
 time.sleep(10)
-order_book.close()
+while True:
+    msg = wsClient.websocket_queue.get(timeout=15)
+    order_book.process_message(msg)
+    print(order_book_btc.get_ask())
+    print(order_book_eth.get_bid())
 ```
 
 ### Testing

--- a/cbpro/order_book.py
+++ b/cbpro/order_book.py
@@ -76,9 +76,6 @@ class OrderBook(object):
 
     def on_sequence_gap(self, gap_start, gap_end):
         self.reset_book()
-        print('Error: messages missing ({} - {}). Re-initializing  book at sequence.'.format(
-            gap_start, gap_end, self._sequence))
-
 
     def add(self, order):
         order = {

--- a/cbpro/order_book.py
+++ b/cbpro/order_book.py
@@ -6,7 +6,6 @@
 
 from sortedcontainers import SortedDict
 from decimal import Decimal
-import Queue
 import pickle
 
 from cbpro.public_client import PublicClient
@@ -277,22 +276,19 @@ if __name__ == '__main__':
     class WebsocketConsole(WebsocketClient):
         def on_open(self):
             self.products = ['BTC-USD', 'ETH-USD']
-            self.websocket_queue = Queue.Queue()
+            self.order_book_btc = OrderBookConsole(product_id='BTC-USD')
+            self.order_book_eth = OrderBookConsole(product_id='ETH-USD')
 
         def on_message(self, msg):
-            self.websocket_queue.put(msg)
-
-    order_book_btc = OrderBookConsole(product_id='BTC-USD')
-    order_book_eth = OrderBookConsole(product_id='ETH-USD')
+            self.order_book_btc.process_message(msg)
+            self.order_book_eth.process_message(msg)
 
     wsClient = WebsocketConsole()
     wsClient.start()
     time.sleep(10)
     try:
         while True:
-            msg = wsClient.websocket_queue.get(timeout=15)
-            order_book_btc.process_message(msg)
-            order_book_eth.process_message(msg)
+            pass
     except KeyboardInterrupt:
         wsClient.close()
     except Exception:

--- a/cbpro/order_book.py
+++ b/cbpro/order_book.py
@@ -6,16 +6,15 @@
 
 from sortedcontainers import SortedDict
 from decimal import Decimal
+import Queue
 import pickle
 
 from cbpro.public_client import PublicClient
 from cbpro.websocket_client import WebsocketClient
 
 
-class OrderBook(WebsocketClient):
+class OrderBook(object):
     def __init__(self, product_id='BTC-USD', log_to=None):
-        super(OrderBook, self).__init__(
-            products=product_id, channels=['full'])
         self._asks = SortedDict()
         self._bids = SortedDict()
         self._client = PublicClient()
@@ -24,18 +23,7 @@ class OrderBook(WebsocketClient):
         if self._log_to:
             assert hasattr(self._log_to, 'write')
         self._current_ticker = None
-
-    @property
-    def product_id(self):
-        ''' Currently OrderBook only supports a single product even though it is stored as a list of products. '''
-        return self.products[0]
-
-    def on_open(self):
-        self._sequence = -1
-        print("-- Subscribed to OrderBook! --\n")
-
-    def on_close(self):
-        print("\n-- OrderBook Socket Closed! --")
+        self.product_id = product_id
 
     def reset_book(self):
         self._asks = SortedDict()
@@ -57,33 +45,34 @@ class OrderBook(WebsocketClient):
             })
         self._sequence = res['sequence']
 
-    def on_message(self, message):
-        if self._log_to:
-            pickle.dump(message, self._log_to)
+    def process_message(self, message):
+        if message.get('product_id') == self.product_id:
+            if self._log_to:
+                pickle.dump(message, self._log_to)
 
-        sequence = message.get('sequence', -1)
-        if self._sequence == -1:
-            self.reset_book()
-            return
-        if sequence <= self._sequence:
-            # ignore older messages (e.g. before order book initialization from getProductOrderBook)
-            return
-        elif sequence > self._sequence + 1:
-            self.on_sequence_gap(self._sequence, sequence)
-            return
+            sequence = message.get('sequence', -1)
+            if self._sequence == -1:
+                self.reset_book()
+                return
+            if sequence <= self._sequence:
+                # ignore older messages (e.g. before order book initialization from getProductOrderBook)
+                return
+            elif sequence > self._sequence + 1:
+                self.on_sequence_gap(self._sequence, sequence)
+                return
 
-        msg_type = message['type']
-        if msg_type == 'open':
-            self.add(message)
-        elif msg_type == 'done' and 'price' in message:
-            self.remove(message)
-        elif msg_type == 'match':
-            self.match(message)
-            self._current_ticker = message
-        elif msg_type == 'change':
-            self.change(message)
+            msg_type = message['type']
+            if msg_type == 'open':
+                self.add(message)
+            elif msg_type == 'done' and 'price' in message:
+                self.remove(message)
+            elif msg_type == 'match':
+                self.match(message)
+                self._current_ticker = message
+            elif msg_type == 'change':
+                self.change(message)
 
-        self._sequence = sequence
+            self._sequence = sequence
 
     def on_sequence_gap(self, gap_start, gap_end):
         self.reset_book()
@@ -249,7 +238,6 @@ if __name__ == '__main__':
     import time
     import datetime as dt
 
-
     class OrderBookConsole(OrderBook):
         ''' Logs real-time changes to the bid-ask spread to the console '''
 
@@ -262,38 +250,58 @@ if __name__ == '__main__':
             self._bid_depth = None
             self._ask_depth = None
 
-        def on_message(self, message):
-            super(OrderBookConsole, self).on_message(message)
+        def process_message(self, message):
+            if message.get('product_id') == self.product_id:
+                super(OrderBookConsole, self).process_message(message)
 
-            # Calculate newest bid-ask spread
-            bid = self.get_bid()
-            bids = self.get_bids(bid)
-            bid_depth = sum([b['size'] for b in bids])
-            ask = self.get_ask()
-            asks = self.get_asks(ask)
-            ask_depth = sum([a['size'] for a in asks])
+                try:
+                    # Calculate newest bid-ask spread
+                    bid = self.get_bid()
+                    bids = self.get_bids(bid)
+                    bid_depth = sum([b['size'] for b in bids])
+                    ask = self.get_ask()
+                    asks = self.get_asks(ask)
+                    ask_depth = sum([a['size'] for a in asks])
 
-            if self._bid == bid and self._ask == ask and self._bid_depth == bid_depth and self._ask_depth == ask_depth:
-                # If there are no changes to the bid-ask spread since the last update, no need to print
-                pass
-            else:
-                # If there are differences, update the cache
-                self._bid = bid
-                self._ask = ask
-                self._bid_depth = bid_depth
-                self._ask_depth = ask_depth
-                print('{} {} bid: {:.3f} @ {:.2f}\task: {:.3f} @ {:.2f}'.format(
-                    dt.datetime.now(), self.product_id, bid_depth, bid, ask_depth, ask))
+                    if self._bid == bid and self._ask == ask and self._bid_depth == bid_depth and self._ask_depth == ask_depth:
+                        # If there are no changes to the bid-ask spread since the last update, no need to print
+                        pass
+                    else:
+                        # If there are differences, update the cache
+                        self._bid = bid
+                        self._ask = ask
+                        self._bid_depth = bid_depth
+                        self._ask_depth = ask_depth
+                        print('{} {} bid: {:.3f} @ {:.2f}\task: {:.3f} @ {:.2f}'.format(
+                            dt.datetime.now(), self.product_id, bid_depth, bid, ask_depth, ask))
+                except Exception:
+                    pass
 
-    order_book = OrderBookConsole()
-    order_book.start()
+    class WebsocketConsole(WebsocketClient):
+        def on_open(self):
+            self.products = ['BTC-USD', 'ETH-USD']
+            self.websocket_queue = Queue.Queue()
+
+        def on_message(self, msg):
+            self.websocket_queue.put(msg)
+
+    order_book_btc = OrderBookConsole(product_id='BTC-USD')
+    order_book_eth = OrderBookConsole(product_id='ETH-USD')
+
+    wsClient = WebsocketConsole()
+    wsClient.start()
+    time.sleep(10)
     try:
         while True:
-            time.sleep(10)
+            msg = wsClient.websocket_queue.get(timeout=15)
+            order_book_btc.process_message(msg)
+            order_book_eth.process_message(msg)
     except KeyboardInterrupt:
-        order_book.close()
+        wsClient.close()
+    except Exception:
+        pass
 
-    if order_book.error:
+    if wsClient.error:
         sys.exit(1)
     else:
         sys.exit(0)

--- a/contributors.txt
+++ b/contributors.txt
@@ -4,3 +4,4 @@ Jeff Gibson
 David Caseria
 Paul Mestemaker
 Drew Rice
+Mike Cardillo


### PR DESCRIPTION
My attempt at addressing #159. I removed the WebsocketClient inheritance from OrderBook. OrderBook is a good data structure, but should process incoming messages from one single open WebsocketClient.

Note: this will break anyone using OrderBook, but I think it's a needed change. Also, the test code in the file uses the python2.7 Queue module, so I'm not sure if we want to change that out for the python3 queue.Queue.

I'm open to any suggestions for changes, as long as we can still remove the amount of open WebsocketClients needed!