### PR TITLE
Fix closed connections bug

### DIFF
--- a/gdax/websocket_client.py
+++ b/gdax/websocket_client.py
@@ -93,7 +93,7 @@ class WebsocketClient(object):
                 data = self.ws.recv()
                 msg = json.loads(data)
             except WebSocketConnectionClosedException as e:
-                self.reconnect()
+                self._reconnect()
             except ValueError as e:
                 self.on_error(e, data=data)
             except Exception as e:


### PR DESCRIPTION
The `while` loop in `_listen` isn't doing what you think it is. 

Calling `recv()` blocks the thread. If no messages are received the connection is closed and a `WebSocketConnectionClosedException` is thrown.  

At this point, we should attempt a reconnection using the parameters previously set.

Sidenote: The conditional on a line ~77 is breaking the entire class. Theres already a PR (#262 ) for this so I didn't make those changes.. however this commit allows us to circumvent that error also