### PR TITLE
Include `sortedcontainers` as a dependency to prevent `ModuleNotFoundError`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ install_requires = [
     'requests==2.13.0',
     'six==1.10.0',
     'websocket-client==0.40.0',
-    'pymongo==3.5.1'
+    'pymongo==3.5.1',
+    'sortedcontainers==1.5.9',
 ]
 
 tests_require = [


### PR DESCRIPTION
Addresses: `ModuleNotFoundError: No module named 'sortedcontainers'`