### PR TITLE
Encode auth signiture as string in JSON payload

### DIFF
--- a/gdax/websocket_client.py
+++ b/gdax/websocket_client.py
@@ -67,7 +67,8 @@ class WebsocketClient(object):
             hmac_key = base64.b64decode(self.api_secret)
             signature = hmac.new(hmac_key, message, hashlib.sha256)
             signature_b64 = base64.b64encode(signature.digest())
-            sub_params['signature'] = signature_b64
+            signiture_str = signature_b64.decode('utf-8')
+            sub_params['signature'] = signiture_str
             sub_params['key'] = self.api_key
             sub_params['passphrase'] = self.api_passphrase
             sub_params['timestamp'] = timestamp


### PR DESCRIPTION
Fixes an issue with Python 3 where encoding the base64 signature bytes in the auth JSON payload would fail with a TypeError.

Here is the error that is addressed in this pull request:
`TypeError: Object of type 'bytes' is not JSON serializable`