### PR TITLE
Fix get_product_trades and get_historic_rates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ gdax/__pycache__/
 .cache/
 .coverage
 tests/__pycache__/
+.pytest_cache

--- a/gdax/public_client.py
+++ b/gdax/public_client.py
@@ -119,7 +119,7 @@ class PublicClient(object):
         """
         return self._get('/products/{}/ticker'.format(str(product_id)))
 
-    def get_product_trades(self, product_id, before='', after='', limit='', result=[]):
+    def get_product_trades(self, product_id, before='', after='', limit=None, result=[]):
         """List the latest trades for a product.
         Args:
              product_id (str): Product
@@ -161,7 +161,7 @@ class PublicClient(object):
 
         result.extend(r.json())
 
-        if 'cb-after' in r.headers and limit is not len(result):
+        if 'cb-after' in r.headers and limit is not len(result) and limit is not None:
             # update limit
             limit -= len(result)
             if limit <= 0:

--- a/gdax/public_client.py
+++ b/gdax/public_client.py
@@ -119,7 +119,7 @@ class PublicClient(object):
         """
         return self._get('/products/{}/ticker'.format(str(product_id)))
 
-    def get_product_trades(self, product_id, before='', after='', limit=None, result=[]):
+    def get_product_trades(self, product_id, before='', after='', limit=None, result=None):
         """List the latest trades for a product.
         Args:
              product_id (str): Product
@@ -144,6 +144,9 @@ class PublicClient(object):
                      "side": "sell"
          }]
         """
+        if result is None:
+            result = []
+
         url = self.url + '/products/{}/trades'.format(str(product_id))
         params = {}
 

--- a/gdax/public_client.py
+++ b/gdax/public_client.py
@@ -202,10 +202,10 @@ class PublicClient(object):
             product_id (str): Product
             start (Optional[str]): Start time in ISO 8601
             end (Optional[str]): End time in ISO 8601
-            granularity (Optional[str]): Desired time slice in seconds
+            granularity (Optional[int]): Desired time slice in seconds
 
         Returns:
-            list: Historic candle data. Example::
+            list: Historic candle data. Example:
                 [
                     [ time, low, high, open, close, volume ],
                     [ 1415398768, 0.32, 4.2, 0.35, 4.2, 12.3 ],
@@ -221,9 +221,9 @@ class PublicClient(object):
         if granularity is not None:
             acceptedGrans = [60, 300, 900, 3600, 21600, 86400]
             if granularity not in acceptedGrans:
-                newGranularity = min(acceptedGrans, key=lambda x:abs(x-granularity))
-                print(granularity,' is not a valid granularity level, using',newGranularity,' instead.')
-                granularity = newGranularity
+                raise ValueError( 'Specified granularity is {}, must be in approved values: {}'.format(
+                        granularity, acceptedGrans) )
+
             params['granularity'] = granularity
 
         return self._get('/products/{}/candles'.format(str(product_id)), params=params)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ websocket-client==0.40.0
 pymongo==3.5.1
 pytest>=3.3.0
 pytest-cov>=2.5.0
+py-dateutil==2.2

--- a/tests/test_public_client.py
+++ b/tests/test_public_client.py
@@ -56,6 +56,8 @@ class TestPublicClient(object):
     def test_get_historic_rates(self, client, start, end, granularity):
         r = client.get_product_historic_rates('BTC-USD', start=start, end=end, granularity=granularity)
         assert type(r) is list
+        for ticker in r:
+            assert( all( [type(x) in (int, float) for x in ticker ] ) )
 
     def test_get_product_24hr_stats(self, client):
         r = client.get_product_24hr_stats('BTC-USD')

--- a/tests/test_public_client.py
+++ b/tests/test_public_client.py
@@ -52,7 +52,7 @@ class TestPublicClient(object):
 
     @pytest.mark.parametrize('start,end,granularity',
                              [(current_time - relativedelta(months=1),
-                               current_time, 10000)])
+                               current_time, 21600)])
     def test_get_historic_rates(self, client, start, end, granularity):
         r = client.get_product_historic_rates('BTC-USD', start=start, end=end, granularity=granularity)
         assert type(r) is list


### PR DESCRIPTION
For a few reasons, these two methods weren't passing their unit tests. I repaired the methods such that they return the correct values and improved the unit tests a little bit as well.