### PR TITLE
Bug fix: params were not being sent to coinbase api.

### DIFF
--- a/cbpro/public_client.py
+++ b/cbpro/public_client.py
@@ -196,7 +196,8 @@ class PublicClient(object):
 
             params['granularity'] = granularity
         return self._send_message('get',
-                                  '/products/{}/candles'.format(product_id))
+                                  '/products/{}/candles'.format(product_id),
+                                  params=params)
 
     def get_product_24hr_stats(self, product_id):
         """Get 24 hr stats for the product.


### PR DESCRIPTION
The call to _send_message was missing the params so the function was not respecting the datetime and granularity parameters when requesting data from coinbase api. So the request would always return whatever data coinbase decided to give to you.