### PR TITLE
Websockets are in a stopped state at initialization.

### DIFF
--- a/cbpro/websocket_client.py
+++ b/cbpro/websocket_client.py
@@ -24,7 +24,7 @@ class WebsocketClient(object):
         self.products = products
         self.channels = channels
         self.type = message_type
-        self.stop = False
+        self.stop = True
         self.error = None
         self.ws = None
         self.thread = None


### PR DESCRIPTION
The self.stop variable should be True at initialization. Correct initial value is desirable because someone may create a websocket client and rely on a conditional test based on this boolean to determine when to start() the socket.