### PR TITLE
Configure travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+language: python
+# cache package wheels (1 cache per python version)
+cache: pip
+python: 3.5
+
+install:
+  - pip install -r requirements.txt
+
+script:
+  - pytest


### PR DESCRIPTION
Reference #312.
Basic CI setup.

This can be enhanced over time to run for different python versions and enforce pep8 at build time.