### PR TITLE
updated authenticated_client.py

### DIFF
--- a/cbpro/authenticated_client.py
+++ b/cbpro/authenticated_client.py
@@ -234,10 +234,10 @@ class AuthenticatedClient(PublicClient):
         # Limit order checks
         if order_type == 'limit':
             if kwargs.get('cancel_after') is not None and \
-                    kwargs.get('tif') != 'GTT':
+                    kwargs.get('time_in_force') != 'GTT':
                 raise ValueError('May only specify a cancel period when time '
                                  'in_force is `GTT`')
-            if kwargs.get('post_only') is not None and kwargs.get('tif') in \
+            if kwargs.get('post_only') is not None and kwargs.get('time_in_force') in \
                     ['IOC', 'FOK']:
                 raise ValueError('post_only is invalid when time in force is '
                                  '`IOC` or `FOK`')


### PR DESCRIPTION
For place_order method 'time_in_force' was written as 'tif' - which is not a standard argument for the coinbase pro API.