### PR TITLE
made `tox` command work and improved some packaging infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ cbpro/__pycache__/
 .coverage
 tests/__pycache__/
 .pytest_cache
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,13 @@ sudo: false
 language: python
 # cache package wheels (1 cache per python version)
 cache: pip
-python: 3.5
+python: 
+  - "2.7"
+  - "3.5"
+  - "3.6"
 
 install:
-  - pip install -r requirements-dev.txt
+  - pip install tox-travis
 
 script:
-  - python -m pytest tests/
+  - tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,3 @@
-sortedcontainers>=1.5.9
-requests==2.13.0
-six==1.10.0
-websocket-client==0.40.0
-pymongo==3.5.1
-pytest>=3.3.0
-python-dateutil>=2.7.3
+-e .
+coverage
+pytest

--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,18 @@
 from setuptools import setup, find_packages
 
 install_requires = [
+    'pymongo>=3.5.1',
+    'python-dateutil',
+    'requests>=2.13.0',
+    'six>=1.10.0',
     'sortedcontainers>=1.5.9',
-    'requests==2.13.0',
-    'six==1.10.0',
-    'websocket-client==0.40.0',
-    'pymongo==3.5.1'
+    'websocket-client>=0.40.0',
 ]
 
 tests_require = [
     'pytest',
-    ]
+    'coverage',
+]
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -41,11 +43,12 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py27, py35, py36
+envlist = py27, py35, py36, py37
 
 [testenv]
 setenv = PYTHONPATH = .
 deps =
     -rrequirements-dev.txt
 commands=
-    python -m pytest -m "not xfail" {posargs: "{toxinidir}/cbpro/tests" --cov-config="{toxinidir}/tox.ini" --cov=cbpro}
-    python -m pytest -m "xfail"     {posargs: "{toxinidir}/cbpro/tests"
+    coverage run -m pytest -rxs {posargs:tests}
+    coverage report --show-missing


### PR DESCRIPTION
- `tox` command now works
- add .tox to .gitignore
- show coverage missing
- add coverage to test requirements
- unpin package requirements
- add py37 to tox
- change travis.yml to use tox
- make requirements-dev.txt always consistent with setup.py