### PR TITLE
Fix OrderBook class and require channels argument for WebsocketClient

### DIFF
--- a/cbpro/order_book.py
+++ b/cbpro/order_book.py
@@ -14,7 +14,8 @@ from cbpro.websocket_client import WebsocketClient
 
 class OrderBook(WebsocketClient):
     def __init__(self, product_id='BTC-USD', log_to=None):
-        super(OrderBook, self).__init__(products=product_id)
+        super(OrderBook, self).__init__(
+            products=product_id, channels=['full'])
         self._asks = SortedDict()
         self._bids = SortedDict()
         self._client = PublicClient()

--- a/cbpro/websocket_client.py
+++ b/cbpro/websocket_client.py
@@ -18,8 +18,21 @@ from cbpro.cbpro_auth import get_auth_headers
 
 
 class WebsocketClient(object):
-    def __init__(self, url="wss://ws-feed.pro.coinbase.com", products=None, message_type="subscribe", mongo_collection=None,
-                 should_print=True, auth=False, api_key="", api_secret="", api_passphrase="", channels=None):
+    def __init__(
+            self,
+            url="wss://ws-feed.pro.coinbase.com",
+            products=None,
+            message_type="subscribe",
+            mongo_collection=None,
+            should_print=True,
+            auth=False,
+            api_key="",
+            api_secret="",
+            api_passphrase="",
+            # Make channels a required keyword-only argument; see pep3102
+            *,
+            # Channel options: ['ticker', 'user', 'matches', 'level2', 'full']
+            channels):
         self.url = url
         self.products = products
         self.channels = channels


### PR DESCRIPTION
This pull request resolves #380 by specifying the `full` channel in the `super()` call in the `OrderBook` constructor.

Since changes to Coinbase's WS api require users to provide the channel(s) to connect to, this pull request also updates the `WebsocketClient` constructor to make `channels` a required keyword argument.

Closes #380
Closes #371 