### PR TITLE
Add authenticated client get_fees method and test

### DIFF
--- a/cbpro/authenticated_client.py
+++ b/cbpro/authenticated_client.py
@@ -995,3 +995,16 @@ class AuthenticatedClient(PublicClient):
 
         """
         return self._send_message('get', '/users/self/trailing-volume')
+
+    def get_fees(self):
+        """ Get your maker & taker fee rates and 30-day trailing volume.
+
+        Returns:
+            dict: Fee information and USD volume::
+                {
+                    "maker_fee_rate": "0.0015",
+                    "taker_fee_rate": "0.0025",
+                    "usd_volume": "25000.00"
+                }
+        """
+        return self._send_message('get', '/fees')

--- a/tests/test_authenticated_client.py
+++ b/tests/test_authenticated_client.py
@@ -186,3 +186,7 @@ class TestAuthenticatedClient(object):
     def test_get_trailing_volume(self, client):
         r = client.get_trailing_volume()
         assert type(r) is list
+
+    def test_get_fees(self, client):
+        r = client.get_fees()
+        assert type(r) is dict


### PR DESCRIPTION
    Add authenticated client get_fees method and test
    
    This adds the ability to get your:
    * current maker & taker fee rates
    * 30-day trailing volume
    
    See: https://docs.pro.coinbase.com/#fees