### PR TITLE
Coinbase rate limits impact calls for arbitrarily large number of pages

### DIFF
--- a/cbpro/authenticated_client.py
+++ b/cbpro/authenticated_client.py
@@ -126,7 +126,7 @@ class AuthenticatedClient(PublicClient):
                 ]
         """
         endpoint = '/accounts/{}/ledger'.format(account_id)
-        return self._send_paginated_message(endpoint, params=kwargs)
+        return self._send_paginated_message(endpoint, params=kwargs, sleep_interval=.2)
 
     def get_account_holds(self, account_id, **kwargs):
         """ Get holds on an account.
@@ -171,7 +171,7 @@ class AuthenticatedClient(PublicClient):
 
         """
         endpoint = '/accounts/{}/holds'.format(account_id)
-        return self._send_paginated_message(endpoint, params=kwargs)
+        return self._send_paginated_message(endpoint, params=kwargs, sleep_interval=.2)
 
     def place_order(self, product_id, side, order_type, **kwargs):
         """ Place an order.
@@ -579,7 +579,7 @@ class AuthenticatedClient(PublicClient):
             params['product_id'] = product_id
         if status is not None:
             params['status'] = status
-        return self._send_paginated_message('/orders', params=params)
+        return self._send_paginated_message('/orders', params=params, sleep_interval=.2)
 
     def get_fills(self, product_id=None, order_id=None, **kwargs):
         """ Get a list of recent fills.
@@ -637,7 +637,7 @@ class AuthenticatedClient(PublicClient):
             params['order_id'] = order_id
         params.update(kwargs)
 
-        return self._send_paginated_message('/fills', params=params)
+        return self._send_paginated_message('/fills', params=params, sleep_interval=.2)
 
     def get_fundings(self, status=None, **kwargs):
         """ Every order placed with a margin profile that draws funding
@@ -676,7 +676,7 @@ class AuthenticatedClient(PublicClient):
         if status is not None:
             params['status'] = status
         params.update(kwargs)
-        return self._send_paginated_message('/funding', params=params)
+        return self._send_paginated_message('/funding', params=params, sleep_interval=.2)
 
     def repay_funding(self, amount, currency):
         """ Repay funding. Repays the older funding records first.

--- a/cbpro/public_client.py
+++ b/cbpro/public_client.py
@@ -300,13 +300,14 @@ class PublicClient(object):
             results = r.json()
             for result in results:
                 yield result
-                time.sleep(sleep_interval)
             # If there are no more pages, we're done. Otherwise update `after`
             # param to get next page.
             # If this request included `before` don't get any more pages - the
             # cbpro API doesn't support multiple pages in that case.
             if not r.headers.get('cb-after') or \
                     params.get('before') is not None:
+                time.sleep(sleep_interval)
                 break
             else:
                 params['after'] = r.headers['cb-after']
+                time.sleep(sleep_interval)

--- a/cbpro/public_client.py
+++ b/cbpro/public_client.py
@@ -5,7 +5,7 @@
 # For public requests to the Coinbase exchange
 
 import requests
-
+import time
 
 class PublicClient(object):
     """cbpro public client API.
@@ -269,7 +269,7 @@ class PublicClient(object):
                                  auth=self.auth, timeout=30)
         return r.json()
 
-    def _send_paginated_message(self, endpoint, params=None):
+    def _send_paginated_message(self, endpoint, params=None, sleep_interval = .34):
         """ Send API message that results in a paginated response.
 
         The paginated responses are abstracted away by making API requests on
@@ -300,6 +300,7 @@ class PublicClient(object):
             results = r.json()
             for result in results:
                 yield result
+                time.sleep(sleep_interval)
             # If there are no more pages, we're done. Otherwise update `after`
             # param to get next page.
             # If this request included `before` don't get any more pages - the


### PR DESCRIPTION
I ran into what looks like a Coinbase API rate limit issue when calling AuthenticatedClient.get_account_history, read the source, and didn't see how API rate limits were being handled in PublicClient._send_paginated_message .

Here's the Coinbase Pro API rate limits page:
https://docs.pro.coinbase.com/#rate-limits

It says:
"PUBLIC ENDPOINTS
We throttle public endpoints by IP: 3 requests per second, up to 6 requests per second in bursts.

PRIVATE ENDPOINTS
We throttle private endpoints by profile ID: 5 requests per second, up to 10 requests per second in bursts."

This patch adds a time.sleep of .2 seconds to paginated calls in the AuthenticatedClient (to meet the 5 request per second limit) and sets a default time.sleep of .34 seconds for all other paginated calls (e.g. the PublicClient).

The changes are simple and easy to read, but I only tested them for performance. I have not tested all of the paginated calls. The changes necessarily make the pulling of multiple pages of data slower.