### PR TITLE
creates channels attributes based on products attribute

### DIFF
--- a/cbpro/websocket_client.py
+++ b/cbpro/websocket_client.py
@@ -70,7 +70,8 @@ class WebsocketClient(object):
             self.url = self.url[:-1]
 
         if self.channels is None:
-            sub_params = {'type': 'subscribe', 'product_ids': self.products}
+            self.channels = [{"name": "ticker", "product_ids": [product_id for product_id in self.products]}]
+            sub_params = {'type': 'subscribe', 'product_ids': self.products, 'channels': self.channels}
         else:
             sub_params = {'type': 'subscribe', 'product_ids': self.products, 'channels': self.channels}
 


### PR DESCRIPTION
While starting a web socket connector, a error has been being raised regarding the lack of channels to subscribe to. I have added one line that creates a channel list based on self.products.