### PR TITLE
Implement stablecoin conversion

### DIFF
--- a/cbpro/authenticated_client.py
+++ b/cbpro/authenticated_client.py
@@ -173,6 +173,33 @@ class AuthenticatedClient(PublicClient):
         endpoint = '/accounts/{}/holds'.format(account_id)
         return self._send_paginated_message(endpoint, params=kwargs)
 
+
+    def convert_stablecoin(self, amount, from_currency, to_currency):
+        """ Convert stablecoin.
+
+            Args:
+                amount (Decimal): The amount to convert.
+                from_currency (str): Currency type (eg. 'USDC')
+                to_currency (str): Currency type (eg. 'USD').
+
+            Returns:
+                dict: Conversion details. Example::
+                    {
+                        "id": "8942caee-f9d5-4600-a894-4811268545db",
+                        "amount": "10000.00",
+                        "from_account_id": "7849cc79-8b01-4793-9345-bc6b5f08acce",
+                        "to_account_id": "105c3e58-0898-4106-8283-dc5781cda07b",
+                        "from": "USD",
+                        "to": "USDC"
+                    }
+
+            """
+        params = {'from': from_currency,
+                  'to': to_currency,
+                  'amount': amount}
+        return self._send_message('post', '/conversions', data=json.dumps(params))
+
+
     def place_order(self, product_id, side, order_type=None, **kwargs):
         """ Place an order.
 

--- a/tests/test_authenticated_client.py
+++ b/tests/test_authenticated_client.py
@@ -107,6 +107,14 @@ class TestAuthenticatedClient(object):
         assert 'type' in r[0]
         assert 'ref' in r[0]
 
+    def test_convert_stablecoin(self, client):
+        r = client.convert_stablecoin('10.0', 'USD', 'USDC')
+        assert type(r) is dict
+        assert 'id' in r
+        assert r['amount'] == '10.00000000'
+        assert r['from'] == 'USD'
+        assert r['to'] == 'USDC'
+
     def test_place_order(self, client):
         r = client.place_order('BTC-USD', 'buy', 'limit',
                                price=0.62, size=0.0144)


### PR DESCRIPTION
Tested in production with the following commands, working as expected.

```
auth_client.convert_stablecoin(10, 'USDC', 'USD')
auth_client.convert_stablecoin(10, 'USD', 'USDC')
```