### PR TITLE
Update requests package version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'sortedcontainers>=1.5.9',
-    'requests>=2.13.0',
+    'requests>=2.25.0',
     'six>=1.10.0',
     'websocket-client>=0.40.0',
     'pymongo>=3.5.1',


### PR DESCRIPTION
- Current requirement `2.13` is 4 years old and causing dependencies issues.
- In my use case I was not able to install the latest version of [web3](https://github.com/ethereum/web3.py) with `cbpro`

