### PR TITLE
Add limit price parameter for stop loss orders

### DIFF
--- a/cbpro/authenticated_client.py
+++ b/cbpro/authenticated_client.py
@@ -462,10 +462,10 @@ class AuthenticatedClient(PublicClient):
 
         params = {'product_id': product_id,
                   'side': side,
-                  'price': price,
+                  'price': price if limit_price is None else limit_price,
                   'order_type': None,
                   'stop': stop_type,
-                  'stop_price': price if limit_price is None else limit_price,
+                  'stop_price': price,
                   'size': size,
                   'funds': funds,
                   'client_oid': client_oid,

--- a/cbpro/authenticated_client.py
+++ b/cbpro/authenticated_client.py
@@ -419,7 +419,8 @@ class AuthenticatedClient(PublicClient):
 
         return self.place_order(**params)
 
-    def place_stop_order(self, product_id, stop_type, price, size=None, funds=None,
+    def place_stop_order(self, product_id, stop_type, price, limit_price=None,
+                         size=None, funds=None,
                          client_oid=None,
                          stp=None,
                          overdraft_enabled=None,
@@ -432,6 +433,7 @@ class AuthenticatedClient(PublicClient):
                       loss: Triggers when the last trade price changes to a value at or below the stop_price.
                       entry: Triggers when the last trade price changes to a value at or above the stop_price
             price (Decimal): Desired price at which the stop order triggers.
+            limit_price (Decimal): Limit price when stop order is triggered (defaults to stop price)
             size (Optional[Decimal]): Desired amount in crypto. Specify this or
                 `funds`.
             funds (Optional[Decimal]): Desired amount of quote currency to use.
@@ -463,7 +465,7 @@ class AuthenticatedClient(PublicClient):
                   'price': price,
                   'order_type': None,
                   'stop': stop_type,
-                  'stop_price': price,
+                  'stop_price': price if limit_price is None else limit_price,
                   'size': size,
                   'funds': funds,
                   'client_oid': client_oid,


### PR DESCRIPTION
Currently, when you create an order with `place_stop_order()` you create a stop _limit_ order where the limit price is equal to the stop price.

This PR adds an optional argument `limit_price` to `place_stop_order()`, allowing the user to specify the limit as well as the stop price.

Note that our `limit_price` argument is equivalent to the [API parameter](https://docs.pro.coinbase.com/#place-a-new-order) `price`, whereas our `price` argument maps to the API parameter `stop_price`. This is a little confusing but I wanted to leave the default `price` arg of the function unchanged to maintain backwards compatibility.