### PR TITLE
fixed trailing volume endpoint

### DIFF
--- a/cbpro/authenticated_client.py
+++ b/cbpro/authenticated_client.py
@@ -1033,7 +1033,7 @@ class AuthenticatedClient(PublicClient):
                 ]
 
         """
-        return self._send_message('get', '/users/self/trailing-volume')
+        return self._send_message('get', '/fees')
 
     def get_fees(self):
         """ Get your maker & taker fee rates and 30-day trailing volume.


### PR DESCRIPTION
This method for the authenticated client wasn't working. With this modification, a properly authenticated client will return your 30-day trailing volume.